### PR TITLE
adjust integration tests and set correct interval

### DIFF
--- a/src/controllers/moviesController.js
+++ b/src/controllers/moviesController.js
@@ -57,7 +57,7 @@ const producersMinMax = (qtd, interval, producersAux) =>{
     
     filteredProds.push({
       producer: x.name,
-      interval: interval,
+      interval: x.numYears,
       previousWin: x.years[0],
       followingWin: x.years[1]
     });


### PR DESCRIPTION
- Fix integration tests to verify the JSON structure returned and to check the default value return on the endpoint;
- Adjust property interval to get the number of years;